### PR TITLE
Major version change: task_helper.sh takes full output control

### DIFF
--- a/files/task_helper.sh
+++ b/files/task_helper.sh
@@ -2,20 +2,74 @@
 
 # Exit with an error message and error code, defaulting to 1
 fail() {
-  # Print a stderr: entry if there were anything printed to stderr
-  if [[ -s $_tmp ]]; then
-    # Hack to try and output valid json by replacing " with \" and removing unprintable characters.
-    echo "{ \"status\": \"error\", \"message\": \"$1\", \"stderr\": \"$(sed 's/"/\\"/g' "$_tmp" | tr -cd '[:print:]')\" }"
-  else
-    echo "{ \"status\": \"error\", \"message\": \"$1\" }"
-  fi
-
-  exit "${2:-1}"
+  helper-output "status" "error"
+  helper-output "message" "$1"
+  exit ${2:-1}
 }
 
 success() {
-  echo "$1"
+  helper-output "status" "success"
+  if [ "$#" -gt 0 ]; then
+    helper-output "message" "$*"
+  fi
   exit 0
+}
+
+# No arguments. Use with a pipe or input redirect as a filter.
+json-escape() {
+  # This is imperfect, and will miss some characters. If we can figure out a
+  # way to get iconv to catch more character types, we might improve that.
+  # 1. Replace backslashes with escape sequences
+  # 2. Replace unicode characters (if possible) with system iconv
+  # 3. Replace other required characters with escape sequences
+  #    Note that this includes two control-characters specifically
+  # 4. Escape newlines (1/2): Replace all newlines with literal tabs
+  # 5. Escape newlines (2/2): Replace all literal tabs with newline escape sequences
+  # 6. Delete any remaining non-printable lines from the stream
+  sed -e 's/\\/\\/g' \
+    | { iconv -t ASCII --unicode-subst="\u%04x" || cat; } \
+    | sed -e 's/"/\\"/' \
+          -e 's/\//\\\//g' \
+          -e "s/$(printf '\b')/\\\b/" \
+          -e "s/$(printf '\f')/\\\f/" \
+          -e 's/\r/\\r/g' \
+          -e 's/\t/\\t/g' \
+          -e "s/$(printf "\x1b")/\\\u001b/g" \
+          -e "s/$(printf "\x0f")/\\\u000f/g" \
+    | tr '\n' '\t' \
+    | sed 's/\t/\\n/g' \
+    | tr -cd '\11\12\15\40-\176'
+}
+
+helper-output() {
+  local key="${1}"
+  local value=$(json-escape <<< "$2")
+  # TODO: ensure no duplicate values
+  _helper_outputs="${_helper_outputs}\"${key}\": \"${value%\\n}\",\n  "
+}
+
+_helper-exit() {
+  # Record the exit code
+  local exit_code=$?
+
+  # Unset the trap
+  trap - EXIT
+
+  # Reset outputs
+  exec 1>&3
+  exec 2>&4
+
+  # Print JSON to stdout
+  printf '{\n'
+  printf '  %s' "$(printf "$_helper_outputs")"
+  printf '%s\n' "\"merged_output\": \"$(json-escape < "$_merged_output")\""
+  printf '}\n'
+
+  # Remove the output tempfile
+  rm "$_merged_output"
+
+  # Resume an orderly exit
+  exit "$exit_code"
 }
 
 # Test for colors. If unavailable, unset variables are ok
@@ -26,17 +80,18 @@ if tput colors &>/dev/null; then
   reset="$(tput sgr0)"
 fi
 
-# Redirect stderr to a temporary file so we can return it upon error.
-# In *nix, any command run in this context or one `fork`ed from it,
-#   e.g. subshells, command substitutions, process substitutions, etc,
-#   will inherit this context, including the redirected file descriptor
-# That is, everything run in this script will redirect stderr to this file
-#   unless explicitly redirected as part of the command
-_tmp="$(mktemp)"
-exec 2>>"$_tmp"
-
 # Use indirection to munge PT_ environment variables
 # e.g. "$PT_version" becomes "$version"
 for v in ${!PT_*}; do
   declare "${v#*PT_}"="${!v}"
 done
+
+# Redirect all output to a tempfile, and trap EXIT. Upon exit, print a Bolt
+# task return JSON string, with the full contents of the tempfile in the
+# "merged_output" key.
+_merged_output="$(mktemp)"
+trap _helper-exit EXIT
+exec 3>&1
+exec 4>&2
+exec 1>> "$_merged_output"
+exec 2>> "$_merged_output"

--- a/files/task_helper.sh
+++ b/files/task_helper.sh
@@ -61,6 +61,12 @@ task-fail() {
   exit ${2:-1}
 }
 
+# DEPRECATED
+fail() {
+  task-output "_deprecation_warning" "WARN: bash_task_helper fail() is deprecated. Please use task-fail() instead."
+  task-fail "$@"
+}
+
 # Public: Set status=success, set a message, and exit the task
 #
 # This function ends the task. The task will return as successful. The function
@@ -77,6 +83,12 @@ task-succeed() {
   task-output "status" "success"
   _task_exit_string="$1"
   exit 0
+}
+
+# DEPRECATED
+success() {
+  task-output "_deprecation_warning" "WARN: bash_task_helper: use of success() is deprecated. Please use task-succeed() instead."
+  task-succeed "$@"
 }
 
 # Public: Set a task output key to a string value

--- a/files/task_helper.sh
+++ b/files/task_helper.sh
@@ -103,12 +103,12 @@ done
 _task_output_keys=()
 _task_output_values=()
 
-# Redirect all output to a tempfile, and trap EXIT. Upon exit, print a Bolt
-# task return JSON string, with the full contents of the tempfile in the
-# "_output" key.
+# Redirect all output (stdin, stderr) to a tempfile, and trap EXIT. Upon exit,
+# print a Bolt task return JSON string, with the full contents of the tempfile
+# in the "_output" key.
 _output_tmpfile="$(mktemp)"
 trap _task-exit EXIT
-exec 3>&1
-exec 4>&2
-exec 1>> "$_output_tmpfile"
-exec 2>> "$_output_tmpfile"
+exec 3>&1 \
+     4>&2 \
+     1>> "$_output_tmpfile" \
+     2>&1

--- a/files/task_helper.sh
+++ b/files/task_helper.sh
@@ -7,7 +7,7 @@ task-fail() {
   exit ${2:-1}
 }
 
-task-success() {
+task-succeed() {
   task-output "status" "success"
   if [ "$#" -gt 0 ]; then
     task-output "message" "$*"

--- a/files/task_helper.sh
+++ b/files/task_helper.sh
@@ -62,7 +62,7 @@ _task-exit() {
   # Print JSON to stdout
   printf '{\n'
   printf '  %s' "$(printf "$_task_outputs")"
-  printf '%s\n' "\"merged_output\": \"$(task-json-escape < "$_merged_output")\""
+  printf '%s\n' "\"_output\": \"$(task-json-escape < "$_merged_output")\""
   printf '}\n'
 
   # Remove the output tempfile

--- a/files/task_helper.sh
+++ b/files/task_helper.sh
@@ -165,10 +165,10 @@ task-json-escape() {
   # 6. Delete any remaining non-printable lines from the stream
   sed -e 's/\\/\\/g' \
     | { iconv -t ASCII --unicode-subst="\u%04x" || cat; } \
-    | sed -e 's/"/\\"/' \
+    | sed -e 's/"/\\"/g' \
           -e 's/\//\\\//g' \
-          -e "s/$(printf '\b')/\\\b/" \
-          -e "s/$(printf '\f')/\\\f/" \
+          -e "s/$(printf '\b')/\\\b/g" \
+          -e "s/$(printf '\f')/\\\f/g" \
           -e 's/\r/\\r/g' \
           -e 's/\t/\\t/g' \
           -e "s/$(printf "\x1b")/\\\u001b/g" \

--- a/files/task_helper.sh
+++ b/files/task_helper.sh
@@ -62,7 +62,7 @@
 task-fail() {
   task-output "status" "error"
   _task_exit_string="$1"
-  task-exit ${2:-1}
+  task-exit "${2:-1}"
 }
 
 # DEPRECATED
@@ -109,8 +109,8 @@ success() {
 #   task-output "maximum" "100"
 #
 task-output() {
-  local key="${1}"
-  local value=$(echo -n "$2" | task-json-escape)
+  local -r key="${1}"
+  local -r value=$(echo -n "$2" | task-json-escape)
 
   # Try to find an index for the key
   for i in "${!_task_output_keys[@]}"; do
@@ -195,8 +195,7 @@ task-json-escape() {
 #
 task-exit() {
   # Record the exit code
-  local exit_code=${1:-$?}
-  local output
+  local -r exit_code=${1:-$?}
 
   # Unset the trap
   trap - EXIT
@@ -206,11 +205,11 @@ task-exit() {
   # to task-succeed, that will still be returned as _output. If the task does
   # not exit successfully, or if the task is running in verbose mode, then full
   # output is returned (including a task-fail user message, if there is one)
-  if [ "$exit_code" -ne 0 -o "$_task_verbose_output" = 'true' ]; then
+  if [[ "$exit_code" -ne 0 || "$_task_verbose_output" = 'true' ]]; then
     # Print the exit string, then set _output to everything that the script has printed
     echo -n "$_task_exit_string"
     task-output '_output' "$(cat "${_output_tmpfile}")"
-  elif [ ! -z "$_task_exit_string" ]; then
+  elif [ -n "$_task_exit_string" ]; then
     # Set _output to just the exit string
     task-output '_output' "${_task_exit_string}"
   fi
@@ -225,7 +224,7 @@ task-exit() {
     # Print each key-value pair
     printf '  "%s": "%s"' "${_task_output_keys[$i]}" "${_task_output_values[$i]}"
     # Print a comma unless it's the last key-value
-    [ ! "$(($i + 1))" -eq "${#_task_output_keys[@]}" ] && printf ','
+    [ ! "$((i + 1))" -eq "${#_task_output_keys[@]}" ] && printf ','
     # Print a newline
     printf '\n'
   done

--- a/files/task_helper.sh
+++ b/files/task_helper.sh
@@ -106,11 +106,36 @@ success() {
 # Examples
 #
 #   task-output "message" "an armadilo crossed the street"
-#   task-output "maximum" "100"
+#   task-output "maximum" "100GB"
 #
 task-output() {
   local -r key="${1}"
   local -r value=$(echo -n "$2" | task-json-escape)
+
+  task-output-json "$key" "$value"
+}
+
+# Public: Set a task output key to a pre-formed valid JSON value
+#
+# Takes a key argument and a value argument, and ensures that upon task exit
+# the key and value will be returned as part of the task output. Unlike
+# task-output, this function requires the USER to ensure that the given value
+# is valid JSON. This is an advanced-user utility. Failure to pass valid JSON
+# will result in malformed task output being produced.
+#
+# $1 - Output key. Should contain only characters that match [A-Za-z0-9-_]
+# $2 - Output value. Should be pre-formatted, valid JSON.
+#
+# Examples
+#
+#   task-output-json "number" 42
+#   task-output-json "string" '"str"'
+#   task-output-json "object" '{"one": "two"}'
+#   task-output-json "array" '["zero", "one", "two"]'
+#
+task-output-json() {
+  local -r key="${1}"
+  local -r value="${2}"
 
   # Try to find an index for the key
   for i in "${!_task_output_keys[@]}"; do
@@ -125,6 +150,7 @@ task-output() {
     _task_output_values=("${_task_output_values[@]}" "${value}")
   fi
 }
+
 
 # Public: Set the task to always return full output
 #

--- a/files/task_helper.sh
+++ b/files/task_helper.sh
@@ -62,11 +62,11 @@ _task-exit() {
   # Print JSON to stdout
   printf '{\n'
   printf '  %s' "$(printf "$_task_outputs")"
-  printf '%s\n' "\"_output\": \"$(task-json-escape < "$_merged_output")\""
+  printf '%s\n' "\"_output\": \"$(task-json-escape < "$_output_tmpfile")\""
   printf '}\n'
 
   # Remove the output tempfile
-  rm "$_merged_output"
+  rm "$_output_tmpfile"
 
   # Resume an orderly exit
   exit "$exit_code"
@@ -88,10 +88,10 @@ done
 
 # Redirect all output to a tempfile, and trap EXIT. Upon exit, print a Bolt
 # task return JSON string, with the full contents of the tempfile in the
-# "merged_output" key.
-_merged_output="$(mktemp)"
+# "_output" key.
+_output_tmpfile="$(mktemp)"
 trap _task-exit EXIT
 exec 3>&1
 exec 4>&2
-exec 1>> "$_merged_output"
-exec 2>> "$_merged_output"
+exec 1>> "$_output_tmpfile"
+exec 2>> "$_output_tmpfile"


### PR DESCRIPTION
This commit refactors task_helper.sh to take full and complete control of output, by trapping EXIT. Review code changes for details.

This is a proposed significant change, and so would mandate a major version bump. After this change, the user experience is as follows.

1. Source the script
2. To use task parameters, optionally use `${parameter_name}` (rather than e.g. `${PT_parameter_name}`)
3. To set output keys, call `task-output key value`
4. Call any of `task-succeed`, `task-fail`, `task-exit`, or just let the script run out (rely on the default EXIT trap)

Regardless of how the user exits the script, the helper will _**ensure valid JSON output**_ is printed to stdout, with:

* Each key-value string pair the user set at any point in the script by calling `task-output $key $value`
* If the user called `task-succeed`:
    * A `status` key containing "success"
    * An `_output` key containing a user message `$1`
* If the user called `task-fail`:
    * A `status` key containing "error"
    * An `_output` key containing all stdout/stderr output, ending with a user message `$1`
* If neither `task-succeed` nor `task-fail` is called but the script terminates with a non-zero exit code:
    * An `_output` key containing all stdout/stderr output

This PR also adds a `task-json-escape` helper function which should work on any of the supported platforms. Design intent is lowest-common-denominator posix tools only. Has been tested on OSX.