### PR TITLE
manifests folder for linting

### DIFF
--- a/manifests/.README
+++ b/manifests/.README
@@ -1,0 +1,2 @@
+This file is to allow the root folder "manifests" to be checked into the module repo
+The Command `pdk release prep` requires the folder to be present

--- a/metadata.json
+++ b/metadata.json
@@ -2,9 +2,9 @@
   "name": "puppetlabs-bash_task_helper",
   "version": "0.1.0",
   "author": "puppetlabs",
-  "summary": "",
+  "summary": "A Bash helper library for use by Puppet Tasks.",
   "license": "Apache-2.0",
-  "source": "",
+  "source": "https://github.com/puppetlabs/puppetlabs-bash_task_helper",
   "dependencies": [
 
   ],


### PR DESCRIPTION
Prior to this commit, the "PDK release PREP" command did not recognise this as a valid module owing to the lack of either a tasks or a manifests directory

This commit adds in empty folder with a readme file explaining its existence