### PR TITLE
Handle missing iconv option gracefully

### DIFF
--- a/files/task_helper.sh
+++ b/files/task_helper.sh
@@ -185,13 +185,15 @@ task-json-escape() {
   # way to get iconv to catch more character types, we might improve that.
   # 1. Replace backslashes with escape sequences
   # 2. Replace unicode characters (if possible) with system iconv
+  #    Note that older iconv versions do not have --unicode-subst
+  #    and will emit an error on stderr when it is used.
   # 3. Replace other required characters with escape sequences
   #    Note that this includes two control-characters specifically
   # 4. Escape newlines (1/2): Replace all newlines with literal tabs
   # 5. Escape newlines (2/2): Replace all literal tabs with newline escape sequences
   # 6. Delete any remaining non-printable lines from the stream
   sed -e 's/\\/\\/g' \
-    | { iconv -t ASCII --unicode-subst="\u%04x" || cat; } \
+    | { iconv -t ASCII --unicode-subst="\u%04x" 2>/dev/null || cat; } \
     | sed -e 's/"/\\"/g' \
           -e 's/\//\\\//g' \
           -e "s/$(printf '\b')/\\\b/g" \


### PR DESCRIPTION
Older iconv versions do not have the --unicode-subst option, which results in an error containing the full unknown command line option to be emitted. This includes the string "\u%04x" which will end up in the returned JSON via the _output key and isn't a valid parsable Unicode escape sequence, which results in JSON parsing errors.

This resolves issue #19