### PR TITLE
Fix task-output-json to work as documented

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -24,4 +24,4 @@ fixtures:
     peadm: 'https://github.com/puppetlabs/puppetlabs-peadm.git'
   symlinks:
     peadm_spec: "#{source_dir}/spec/fixtures/modules/peadm/spec/acceptance/peadm_spec/"
-    bash_task_helper: "${source_dir}"
+    bash_task_helper: "#{source_dir}"

--- a/examples/mytask.sh
+++ b/examples/mytask.sh
@@ -1,15 +1,21 @@
 #!/usr/bin/env bash
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC2154
 # This is disabled in CI, but we'll disable it here as well
 declare PT__installdir
 source "$PT__installdir/bash_task_helper/files/task_helper.sh"
 
-if puppet resource service puppet | grep -q stopped; then
-    #Start the Puppet service
-     puppet resource service puppet ensure=running || task-fail "Couldn't start puppet service"
-else
-  task-fail "Puppet is already running or not installed"
+if [ "$run_type" == 'fail' ]; then
+  task-fail "This task failed"
+elif [ "$run_type" == 'pass' ]; then
+  task-succeed "This task succeeded"
+elif [ "$run_type" == 'output' ]; then
+  task-output "string1" "abcd"
+  task-output "string-numeric" 42
+  task-output-json "string2" '"abcd"'
+  task-output-json "number" 42
+  task-output-json "bool" true
+  task-output "complex-string" "This is a \"complex string\".\n\tSecond line."
 fi
 
 task-succeed

--- a/files/task_helper.sh
+++ b/files/task_helper.sh
@@ -113,7 +113,7 @@ task-output() {
   local -r key="${1}"
   local -r value=$(echo -n "$2" | task-json-escape)
 
-  task-output-json "$key" "$value"
+  task-output-json "$key" "\"$value\""
 }
 
 # Public: Set a task output key to a pre-formed valid JSON value
@@ -251,7 +251,7 @@ task-exit() {
   printf '{\n'
   for i in "${!_task_output_keys[@]}"; do
     # Print each key-value pair
-    printf '  "%s": "%s"' "${_task_output_keys[$i]}" "${_task_output_values[$i]}"
+    printf '  "%s": %s' "${_task_output_keys[$i]}" "${_task_output_values[$i]}"
     # Print a comma unless it's the last key-value
     [ ! "$((i + 1))" -eq "${#_task_output_keys[@]}" ] && printf ','
     # Print a newline

--- a/spec/tasks/task_spec.rb
+++ b/spec/tasks/task_spec.rb
@@ -3,7 +3,7 @@ require 'json'
 
 describe 'bash_task_helper' do
   context 'when using the helper script' do
-    it {
+    subject(:task) do
       # Tasks expect certain PT_ environment variables to be set
       # We only need _installdir, so set it one directory up from the module root
       ENV['PT__installdir'] = File.join(File.dirname(__FILE__), '../fixtures/modules/')
@@ -11,8 +11,37 @@ describe 'bash_task_helper' do
       # Get the path to the task based on the absolute path of this file
       task = File.join(File.dirname(__FILE__), '../../examples/mytask.sh')
       out = `#{task}`
-      # Success for this task is essentially determined by if we get a valid JSON object back
-      expect(['error', 'success'].include?(out['status']))
-    }
+      JSON.parse(out)
+    end
+
+    before(:each) do
+      ENV['PT_run_type'] = run_type.to_s
+    end
+
+    context 'when succeeding' do
+      let(:run_type) { :pass }
+
+      it { is_expected.to include('status' => 'success') }
+      it { is_expected.to include('_output' => 'This task succeeded') }
+    end
+
+    context 'when failing' do
+      let(:run_type) { :fail }
+
+      it { is_expected.to include('status' => 'error') }
+      it { is_expected.to include('_output' => 'This task failed') }
+    end
+
+    context 'when testing output functions' do
+      let(:run_type) { :output }
+
+      it { is_expected.to include('status' => 'success') }
+      it { is_expected.to include('string1' => 'abcd') }
+      it { is_expected.to include('string-numeric' => '42') }
+      it { is_expected.to include('string2' => 'abcd') }
+      it { is_expected.to include('number' => 42) }
+      it { is_expected.to include('bool' => true) }
+      it { is_expected.to include('complex-string' => "This is a \"complex string\".\n\tSecond line.") }
+    end
   end
 end


### PR DESCRIPTION
Currently the task_output_keys/values are always printed with double quotes around the value, preventing task-output-json from working as intended.

Additionally, this includes a refactoring of the unit test as the current one is flawed and does not test anything meaningful.