### PR TITLE
Fix unit tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -24,3 +24,4 @@ fixtures:
     peadm: 'https://github.com/puppetlabs/puppetlabs-peadm.git'
   symlinks:
     peadm_spec: "#{source_dir}/spec/fixtures/modules/peadm/spec/acceptance/peadm_spec/"
+    bash_task_helper: "${source_dir}"

--- a/spec/tasks/task_spec.rb
+++ b/spec/tasks/task_spec.rb
@@ -6,7 +6,7 @@ describe 'bash_task_helper' do
     it {
       # Tasks expect certain PT_ environment variables to be set
       # We only need _installdir, so set it one directory up from the module root
-      ENV['PT__installdir'] = File.join(File.dirname(__FILE__), '../../../')
+      ENV['PT__installdir'] = File.join(File.dirname(__FILE__), '../fixtures/modules/')
 
       # Get the path to the task based on the absolute path of this file
       task = File.join(File.dirname(__FILE__), '../../examples/mytask.sh')


### PR DESCRIPTION
This commit adds the module itself to the fixtures so that the name is corrected without the puppetlabs- prefix.  It also changes the PT_installdir to account for this