### PR TITLE
fix: Properly escape backslashes

### DIFF
--- a/examples/mytask.sh
+++ b/examples/mytask.sh
@@ -15,7 +15,8 @@ elif [ "$run_type" == 'output' ]; then
   task-output-json "string2" '"abcd"'
   task-output-json "number" 42
   task-output-json "bool" true
-  task-output "complex-string" "This is a \"complex string\".\n\tSecond line."
+  task-output "complex-string" $'This is a "complex string".\n\tSecond line.'
+  task-output "escape-backslash" "\\ No newline"
 fi
 
 task-succeed

--- a/files/task_helper.sh
+++ b/files/task_helper.sh
@@ -192,7 +192,7 @@ task-json-escape() {
   # 4. Escape newlines (1/2): Replace all newlines with literal tabs
   # 5. Escape newlines (2/2): Replace all literal tabs with newline escape sequences
   # 6. Delete any remaining non-printable lines from the stream
-  sed -e 's/\\/\\/g' \
+  sed -e 's/\\/\\\\/g' \
     | { iconv -t ASCII --unicode-subst="\u%04x" 2>/dev/null || cat; } \
     | sed -e 's/"/\\"/g' \
           -e 's/\//\\\//g' \

--- a/spec/tasks/task_spec.rb
+++ b/spec/tasks/task_spec.rb
@@ -42,6 +42,7 @@ describe 'bash_task_helper' do
       it { is_expected.to include('number' => 42) }
       it { is_expected.to include('bool' => true) }
       it { is_expected.to include('complex-string' => "This is a \"complex string\".\n\tSecond line.") }
+      it { is_expected.to include('escape-backslash' => '\ No newline') }
     end
   end
 end


### PR DESCRIPTION
task-json-escape was not properly escaping backslashes in source strings. This fixes the issue, adds a test, and corrects a bad test which masked the problem.