### PR TITLE
(MAINT) Update autorelease workflow

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -1,72 +1,15 @@
-name: "Auto release"
+name: "Release Prep"
 
 on:
   workflow_dispatch:
-
-env:
-  CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    inputs:
+      version:
+        description: "Module version to be released. Must be a valid semver string. (1.2.3)"
+        required: true
 
 jobs:
-  auto_release:
-    name: "Automatic release prep"
-    runs-on: ubuntu-20.04
-
-    steps:
-    - name: "Checkout Source"
-      if: ${{ github.repository_owner == 'puppetlabs' }}
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        persist-credentials: false
-
-    - name: "PDK Release prep"
-      uses: docker://puppet/puppet-dev-tools:4.x
-      with:
-        args: 'pdk release prep --force --debug'
-      env:
-        CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: "Get Version"
-      if: ${{ github.repository_owner == 'puppetlabs' }}
-      id: gv
-      run: |
-        echo "ver=$(jq --raw-output .version metadata.json)" >> $GITHUB_OUTPUT
-
-    - name: "Check if a release is necessary"
-      if: ${{ github.repository_owner == 'puppetlabs' }}
-      id: check
-      run: |
-        git diff --quiet CHANGELOG.md && echo "release=false" >> $GITHUB_OUTPUT || echo "release=true" >> $GITHUB_OUTPUT
-
-    - name: "Commit changes"
-      if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
-      run: |
-        git config --local user.email "${{ github.repository_owner }}@users.noreply.github.com"
-        git config --local user.name "GitHub Action"
-        git add .
-        git commit -m "Release prep v${{ steps.gv.outputs.ver }}"
-
-    - name: Create Pull Request
-      id: cpr
-      uses: puppetlabs/peter-evans-create-pull-request@v3
-      if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: "Release prep v${{ steps.gv.outputs.ver }}"
-        branch: "release-prep"
-        delete-branch: true
-        title: "Release prep v${{ steps.gv.outputs.ver }}"
-        body: |
-          Automated release-prep through [pdk-templates](https://github.com/puppetlabs/pdk-templates/blob/main/moduleroot/.github/workflows/auto_release.yml.erb) from commit ${{ github.sha }}. 
-          Please verify before merging:
-          - [ ] last [nightly](https://github.com/${{ github.repository }}/actions/workflows/nightly.yml) run is green
-          - [ ] [Changelog](https://github.com/${{ github.repository }}/blob/release-prep/CHANGELOG.md) is readable and has no unlabeled pull requests
-          - [ ] Ensure the [changelog](https://github.com/${{ github.repository }}/blob/release-prep/CHANGELOG.md) version and [metadata](https://github.com/${{ github.repository }}/blob/release-prep/metadata.json) version match
-        labels: "maintenance"
-
-    - name: PR outputs
-      if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
-      run: |
-        echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
-        echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
-
+  release_prep:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/module_release_prep.yml@main"
+    with:
+      version: "${{ github.event.inputs.version }}"
+    secrets: "inherit"


### PR DESCRIPTION
Following the PDK conversion performed recently, the auto_release workflow needs to be updated as it no longer works. The new workflow calls the predefined workflow store in CAT_github_actions.